### PR TITLE
Enable support for recreating extracted communication patterns

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 from scipy.stats import shapiro
 from model.parameter import Parameter
 
-
 def bootstrap_results(results_dir=Path("results"), clean=False):
     """
     Setup where results are stored


### PR DESCRIPTION
This PR is to track an effort to have better communication pattern reproducibility in the benchmark. 
Before this PR can be merged, the following tasks need to be complete:

- [x] Remove arbitrary limit on number of benchmark samples that can occur
- [ ] Define new input-file format which contains the following information. The format for the data should be defined somewhere public. The format should allow the following data to be extracted:
  - How to pack data
  - How often to update data vs how often to recreate the database
- [ ] When recreating a communication pattern (from input file) change the logic to allow for custom amounts of `L7_Update()` calls to `L7_Setup()` calls (ratio of Updates to Setups)
- [ ] Change behavior of benchmark so that, when recreating a communication pattern, information on discrete samples is better displayed
- [ ] Change logic so that the benchmark can run in creation mode (from file) or from parameter-based approximation (irregular parameter generation from distributions)

More todos will likely be added as I get further into working on this. 